### PR TITLE
fix post cohort endpoint to accept name and users

### DIFF
--- a/src/controllers/cohort.js
+++ b/src/controllers/cohort.js
@@ -2,16 +2,14 @@ import { createCohort, getAllCohorts, getCohortById } from '../domain/cohort.js'
 import { sendDataResponse, sendMessageResponse } from '../utils/responses.js'
 import * as validation from '../utils/validationFunctions.js'
 import ERR from '../utils/errors.js'
-import { dateRegex } from '../utils/regexMatchers.js'
 
 export const create = async (req, res) => {
-  const { startDate, endDate } = req.body
+  const { name, users, startDate, endDate } = req.body
 
-  if (!startDate || !endDate) {
-    return sendMessageResponse(res, 400, { error: ERR.DATE_REQUIRED })
-  }
-  if (!dateRegex.test(startDate) || !dateRegex.test(endDate)) {
-    return sendMessageResponse(res, 400, { error: ERR.DATE_FORMATTING })
+  try {
+    validation.validateCreateCohort(name, users, startDate, endDate)
+  } catch (e) {
+    return sendDataResponse(res, 400, { error: e.message })
   }
 
   try {
@@ -19,9 +17,14 @@ export const create = async (req, res) => {
       startDate,
       endDate
     )
-    const createdCohort = await createCohort(parsedStartDate, parsedEndDate)
+    const createdCohort = await createCohort(
+      name,
+      users,
+      parsedStartDate,
+      parsedEndDate
+    )
 
-    return sendDataResponse(res, 201, createdCohort)
+    return sendDataResponse(res, 201, { cohort: createdCohort })
   } catch (e) {
     console.error('error creating cohort:', e)
     if (e.message === ERR.DATE_REQUIRED || e.message === ERR.DATE_FORMATTING) {

--- a/src/controllers/cohort.js
+++ b/src/controllers/cohort.js
@@ -9,7 +9,7 @@ export const create = async (req, res) => {
   try {
     validation.validateCreateCohort(name, users, startDate, endDate)
   } catch (e) {
-    return sendDataResponse(res, 400, { error: e.message })
+    return sendMessageResponse(res, 400, { error: e.message })
   }
 
   try {

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -33,5 +33,7 @@ export default {
   UNABLE_TO_GET_USER: 'Unable to get the user',
   UNABLE_TO_UPDATE_POST: 'Unable to update post',
   UNABLE_TO_GET_COHORTS: 'Unable to get the cohorts',
-  UNABLE_TO_GET_COHORT: 'Unable to get the cohort'
+  UNABLE_TO_GET_COHORT: 'Unable to get the cohort',
+  COHORT_NAME_REQUIRED: 'Cohort name is required',
+  COHORT_USERS_REQUIRED: 'Cohort users is required'
 }

--- a/src/utils/validationFunctions.js
+++ b/src/utils/validationFunctions.js
@@ -54,3 +54,21 @@ export function validateCanModify(req) {
   }
   return true
 }
+
+export function validateCreateCohort(name, users, startDate, endDate) {
+  if (!name) {
+    throw Error(ERR.COHORT_NAME_REQUIRED)
+  }
+
+  if (!users) {
+    throw Error(ERR.COHORT_USERS_REQUIRED)
+  }
+
+  if (!startDate || !endDate) {
+    throw Error(ERR.DATE_REQUIRED)
+  }
+
+  if (!dateRegex.test(startDate) || !dateRegex.test(endDate)) {
+    throw Error(ERR.DATE_FORMATTING)
+  }
+}


### PR DESCRIPTION
The POST cohort endpoint only accepted a start and end date. This has now been fixed to also accept a cohort name and list of users.